### PR TITLE
Fixing return of getfromhash on error

### DIFF
--- a/src/hash/hash.c
+++ b/src/hash/hash.c
@@ -91,27 +91,24 @@ void *addtohash(HashTable *hash, char *key, char *value) {
   Gets a value from a hash using the provided key.
   @param hash A pointer to the HashTable.
   @param key A char pointer representing the key.
-  @return Return a char pointer to the value. return (void *)-1 if hash is NULL
+  @return Return a char pointer to the value. return "\0" if hash is NULL
   or if the provided key does not have a value.
 */
 char *getfromhash(HashTable *hash, char *key) {
   if (hash == NULL) {
-    return (void *)-1;
+    return "\0";
   }
   unsigned int index = hashfunc(key);
   LinkedList *item = hash->bucket[index];
   if (item == NULL) {
-    return (void *)-1;
+    return "\0";
   }
   void *value;
   for (int i = 0; i < item->size; i++) {
     value = getfromindex(item, i);
-    if (value == NULL) {
-      continue;
-    }
     if (strcmp(((KeyValue *)value)->key, key) == 0) {
       return ((KeyValue *)value)->value;
     }
   }
-  return (void *)-1;
+  return "\0";
 }

--- a/test/test_hash.h
+++ b/test/test_hash.h
@@ -41,8 +41,8 @@ void test_getfromhash() {
   char *value = getfromhash(hash, "key1");
   assert(value != -1 && strcmp(value, "value1") == 0);
   value = getfromhash(hash, "nonexistent");
-  assert(value == -1);
-  assert(getfromhash(NULL, "key1") == -1);
+  assert(strcmp(value, "\0") == 0);
+  assert(strcmp(getfromhash(NULL, "key1"), "\0") == 0);
   teardown(hash);
   printf("test_getfromhash passed\n");
 }


### PR DESCRIPTION
- Before, the return of getfromhash function in case of errors were -1. Now, to comply with the type of the function (char *), the return in case of errors is 0.